### PR TITLE
Add Codecov to CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,10 @@
 name: lint
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
 jobs:
   run_lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 name: lint
 on: [pull_request, workflow_dispatch]
 jobs:
-  run_tests:
+  run_lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,8 @@ jobs:
         with:
           node-version: 16.x
       - run: npm install --production=false
-      - run: npm test
+      - run: npm test -- --coverage
+      - uses: codecov/codecov-action@v2
 
   run_regression_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,10 @@
 name: test
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
 jobs:
   run_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,20 @@ on: [pull_request, workflow_dispatch]
 jobs:
   run_tests:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        name: Test Node.js 16.x
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+      - run: npm install --production=false
+      - run: npm test
+
+  run_regression_tests:
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x]
     steps:
       - uses: actions/checkout@v2
         name: Test Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
This PR adds [Codecov](https://codecov.io) to this repository

It also refactors the test CI step to separate "regression" tests from the "main" test suite.  This allows us to avoid repeating our coverage report generation for every version of Node we want to test against.

Note: Right now codecov is saying it's "missing base report" because we don't have any report for the `main` branch to compare the PR against.  I believe this will be resolved after merging.

Resolves #12