### PR TITLE
Support NPM publication

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
-      "project": "./tsconfig.json"
+      "project": "./tsconfig.dev.json"
     },
     "plugins": [
       "@typescript-eslint",

--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -1,0 +1,21 @@
+name: publish dry run (npm)
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm run build
+      - run: npm publish --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: publish (npm)
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm run build
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,3 @@ dist
 
 # TernJS port file
 .tern-port
-
-# Built directory
-lib/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog for @permanentorg/sdk
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.0] - 2022-03-21
+### Added
+- A placeholder project / release with no completed functionality.
+
+[Unreleased]: https://github.com/permanentorg/permanent-sdk/base/compare/@tvkitchen/base-constants@v0.0.0...HEAD
+[0.0.0]: https://github.com/permanentorg/permanent-sdk/base/releases/tag/v0.0.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # @permanentorg/sdk
 This project is a TypeScript SDK for interfacing with Permanent.org's API.
 
+You can view [the project's changelog](CHANGELOG.md) to learn more about our releases.
+
 ## Code
 
 The project is organized as follows:
@@ -19,6 +21,8 @@ The project is organized as follows:
 Contributors to this repository agree to adhere to the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). To report violations, get in touch with engineers@permanent.org.
 
 The version of NodeJS used for development is specified in `.node-version` located at the project root.
+
+Be sure to include updates to the [changelog](CHANGELOG.md) as part of any contribution.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# permanent-sdk
+# @permanentorg/sdk
 This project is a TypeScript SDK for interfacing with Permanent.org's API.
 
 ## Code

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,0 +1,8 @@
+## Release Process
+
+Here are the steps to follow in order to release a new version of this package:
+
+1. Update the package version in [package.json](../package.json)
+2. Create a new release section in [CHANGELOG.md](../CHANGELOG.md)
+3. Open a PR with the above changes.
+4. Once merged, use GitHub's release interface to publish a new release (tag name `v#.#.#` to match the package.json value).

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,10 @@
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
+  globals: {
+    "ts-jest": {
+      tsconfig: 'tsconfig.dev.json',
+    },
+  },
   preset: 'ts-jest',
   testEnvironment: 'node',
   testPathIgnorePatterns: ["<rootDir>/lib/"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
-  "name": "permanent-sdk",
+  "name": "@permanentorg/sdk",
   "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "permanent-sdk",
+      "name": "@permanentorg/sdk",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^3.2.0"
       },
       "devDependencies": {
+        "@tsconfig/esm": "^1.0.0",
         "@tsconfig/node14": "^1.0.1",
         "@types/jest": "^27.4.0",
         "@typescript-eslint/eslint-plugin": "^5.10.0",
@@ -27,6 +28,9 @@
       },
       "engines": {
         "node": ">=14.0"
+      },
+      "funding": {
+        "url": "https://permanent.org/donate/"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1107,6 +1111,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@tsconfig/esm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@tsconfig/esm/-/esm-1.0.0.tgz",
+      "integrity": "sha512-vrMQ/cCJ4YBj1iAdbh4Pmaw2aEdwwyjhM8KA9wOjHsm+aPvCnV2/rYY6zzpOW6UuYrrmZBRjIO75/X+e0CXZ5w==",
+      "dev": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.1",
@@ -6756,6 +6766,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true
+    },
+    "@tsconfig/esm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@tsconfig/esm/-/esm-1.0.0.tgz",
+      "integrity": "sha512-vrMQ/cCJ4YBj1iAdbh4Pmaw2aEdwwyjhM8KA9wOjHsm+aPvCnV2/rYY6zzpOW6UuYrrmZBRjIO75/X+e0CXZ5w==",
       "dev": true
     },
     "@tsconfig/node14": {

--- a/package.json
+++ b/package.json
@@ -2,10 +2,13 @@
   "name": "permanent-sdk",
   "version": "0.0.0",
   "description": "Functional Node.js SDK for Permanent.org",
-  "main": "src/index.ts",
+  "module": "dist/esm/index.js",
+  "main": "dist/cjs/index.js",
   "scripts": {
     "lint": "eslint ./src --ext .ts",
-    "build": "tsc",
+    "build": "npm run build:node && npm run build:browser",
+    "build:node": "tsc -p tsconfig.node.json",
+    "build:browser": "tsc -p tsconfig.browser.json",
     "test": "jest"
   },
   "repository": {
@@ -31,6 +34,7 @@
   },
   "homepage": "https://github.com/PermanentOrg/permanent-sdk#readme",
   "devDependencies": {
+    "@tsconfig/esm": "^1.0.0",
     "@tsconfig/node14": "^1.0.1",
     "@types/jest": "^27.4.0",
     "@typescript-eslint/eslint-plugin": "^5.10.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "permanent-sdk",
+  "name": "@permanentorg/sdk",
   "version": "0.0.0",
   "description": "Functional Node.js SDK for Permanent.org",
   "module": "dist/esm/index.js",
@@ -15,6 +15,7 @@
     "type": "git",
     "url": "git+https://github.com/PermanentOrg/permanent-sdk.git"
   },
+  "funding": "https://permanent.org/donate/",
   "author": {
     "name": "Permanent.org",
     "email": "engineers@permanent.org",
@@ -23,6 +24,11 @@
   "contributors": [
     {
       "name": "Natalie Martin"
+    },
+    {
+      "name": "Daniel Schultz",
+      "email": "slifty@gmail.com",
+      "url": "https://slifty.com"
     }
   ],
   "license": "MIT",
@@ -32,6 +38,9 @@
   "engines": {
     "node": ">=14.0"
   },
+  "files": [
+    "dist"
+  ],
   "homepage": "https://github.com/PermanentOrg/permanent-sdk#readme",
   "devDependencies": {
     "@tsconfig/esm": "^1.0.0",

--- a/tsconfig.browser.json
+++ b/tsconfig.browser.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@tsconfig/esm/tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "outDir": "dist/esm",
+    "declaration": true,
+    "moduleResolution": "node"
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "**/*.test.ts"
+  ]
+}

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -1,13 +1,9 @@
 {
   "extends": "@tsconfig/node14/tsconfig.json",
   "compilerOptions": {
-    "outDir": "lib",
-    "declaration": true
+    "noEmit": true
   },
   "include": [
     "src"
-  ],
-  "exclude": [
-    "**/*.spec.ts"
   ]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@tsconfig/node14/tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "dist/cjs",
+    "declaration": true
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "**/*.test.ts"
+  ]
+}


### PR DESCRIPTION
This PR adds logic for (dry-run) publishing to NPM whenever we release a new github version.

I'm starting this with --dry-run enabled because I don't want to *actually* publish anything until we're sure our github hooks are properly configured.  Once that's done I'll open a new PR to remove the `--dry-run` flag.

Part of the changes involve changing what and where we build for distribution.

Related to #20 