### PR TITLE
Define API type `FolderVo`

### DIFF
--- a/src/types/api/FolderVo.ts
+++ b/src/types/api/FolderVo.ts
@@ -1,3 +1,16 @@
-// This is a placeholder interface which will ultimately be populated
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface FolderVo {}
+export interface FolderVo {
+  // These fields map to those defined in the base library ArchiveVO
+  // https://github.com/PermanentOrg/back-end/blob/main/api/core/folder/vo/folder.vo.php
+  folderId: number;
+  archiveId: number;
+  displayName: string;
+  displayDT: string;
+
+}
+
+export const defaultFolderVo: FolderVo = {
+  folderId: 0,
+  archiveId: 0,
+  displayName: '',
+  displayDT: '',
+};


### PR DESCRIPTION
This PR populates the`FoldeVo` type and creates the utilities to covert from the API `FolderVo` to sdk `FolderVo`.

- [x] Create other types `FolderVo` depends on
- [x] Populate `FolderVo` type


Fixes : #17 