### PR TITLE
Add link:fix command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "dist/cjs/index.js",
   "scripts": {
     "lint": "eslint ./src --ext .ts",
+    "lint:fix": "eslint ./src --fix --ext .ts",
     "build": "npm run build:node && npm run build:browser",
     "build:node": "tsc -p tsconfig.node.json",
     "build:browser": "tsc -p tsconfig.browser.json",


### PR DESCRIPTION
Runing npm run lint:fix would now easily repair the errors
that are shown by npm run lint.

Signed-off-by: fenn-cs <fenn25.fn@gmail.com>