### PR TITLE
Move type guards

### DIFF
--- a/src/types/sdk/RecordType.ts
+++ b/src/types/sdk/RecordType.ts
@@ -1,3 +1,5 @@
+import { generateEnumTypeguard } from '../../utils';
+
 // These types are defined in the permanent backend:
 // https://github.com/PermanentOrg/back-end/blob/main/library/definition/perm.constants.php
 export enum RecordType {
@@ -16,3 +18,5 @@ export enum RecordType {
   Unknown = 'type.record.unknown',
   Video = 'type.record.video',
 }
+
+export const isRecordType = generateEnumTypeguard(RecordType);

--- a/src/types/sdk/Status.ts
+++ b/src/types/sdk/Status.ts
@@ -1,3 +1,5 @@
+import { generateEnumTypeguard } from '../../utils';
+
 // These types are defined in the permanent backend:
 // https://github.com/PermanentOrg/back-end/blob/main/library/definition/perm.constants.php
 export enum Status {
@@ -11,3 +13,5 @@ export enum Status {
   Pending = 'status.generic.pending',
   Undefined = 'status.generic.undefined',
 }
+
+export const isStatus = generateEnumTypeguard(Status);

--- a/src/utils/generateEnumTypeguard.ts
+++ b/src/utils/generateEnumTypeguard.ts
@@ -1,5 +1,3 @@
-import { RecordType, Status } from '../types';
-
 // This is a modified version of code written by StackOverflow user @jcalz
 // https://stackoverflow.com/a/58278753/159522
 export const generateEnumTypeguard = <GenericEnum>(genericEnum: GenericEnum) => (
@@ -9,6 +7,3 @@ export const generateEnumTypeguard = <GenericEnum>(genericEnum: GenericEnum) => 
     return validTokens.includes(token);
   }
 );
-
-export const isRecordType = generateEnumTypeguard(RecordType);
-export const isStatus = generateEnumTypeguard(Status);

--- a/src/utils/recordVoToRecord.ts
+++ b/src/utils/recordVoToRecord.ts
@@ -2,8 +2,12 @@ import type {
   RecordVo,
   Record,
 } from '../types';
-import { RecordType, Status } from '../types';
-import { isRecordType, isStatus } from './generateEnumTypeguard';
+import {
+  RecordType,
+  Status,
+  isRecordType,
+  isStatus,
+} from '../types';
 
 const recordTypeToRecordType = (recordType: string): RecordType => (
   isRecordType(recordType) ? recordType : RecordType.Unknown


### PR DESCRIPTION
This PR moves our enum type guard definitions to be defined alongside the enums.

Resolves #38