### PR TITLE
Specify public package

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,5 +63,8 @@
   "dependencies": {
     "ajv": "^8.11.0",
     "node-fetch": "^2.6.7"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
This PR tells npm that we want to publish the package publicly.

Without this, npm rejects the package since private packages are a paid features (plus we don't want it private anyway so)