### PR TITLE
Add slug to Archive type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `Archive` now has a [`slug`](https://developer.mozilla.org/en-US/docs/Glossary/Slug) field.
 
 ## [0.5.1] - 2023-02-28
 ### Fixed

--- a/src/sdk/__tests__/__snapshots__/getArchives.test.ts.snap
+++ b/src/sdk/__tests__/__snapshots__/getArchives.test.ts.snap
@@ -6,12 +6,14 @@ Array [
     "createdAt": 2022-06-23T18:33:43.000Z,
     "id": 1,
     "name": "dan",
+    "slug": "0001-0000",
     "updatedAt": 2022-06-23T18:33:57.000Z,
   },
   Object {
     "createdAt": 2022-06-23T18:34:25.000Z,
     "id": 20,
     "name": "another test account",
+    "slug": "000k-0000",
     "updatedAt": 2022-06-23T19:38:01.000Z,
   },
 ]

--- a/src/types/api/ArchiveVo.ts
+++ b/src/types/api/ArchiveVo.ts
@@ -6,6 +6,7 @@ export interface ArchiveVo extends BaseVo {
   // These fields map to those defined in the base library ArchiveVO
   // https://github.com/PermanentOrg/back-end/blob/main/library/base/vo/base.archive.vo.php
   archiveId: number;
+  archiveNbr: string;
   fullName: string;
 }
 
@@ -14,6 +15,9 @@ export const archiveVoSchema: JSONSchemaType<ArchiveVo> = {
   properties: {
     archiveId: {
       type: 'integer',
+    },
+    archiveNbr: {
+      type: 'string',
     },
     fullName: {
       type: 'string',
@@ -27,6 +31,7 @@ export const archiveVoSchema: JSONSchemaType<ArchiveVo> = {
   },
   required: [
     'archiveId',
+    'archiveNbr',
     'fullName',
     'createdDT',
     'updatedDT',

--- a/src/types/sdk/Archive.ts
+++ b/src/types/sdk/Archive.ts
@@ -1,5 +1,6 @@
 export interface Archive {
   id: number;
+  slug: string;
   name: string;
   readonly createdAt: Date;
   readonly updatedAt: Date;

--- a/src/utils/__tests__/archiveVoToArchive.test.ts
+++ b/src/utils/__tests__/archiveVoToArchive.test.ts
@@ -4,6 +4,7 @@ describe('archiveVoToArchive', () => {
   it('should properly populate an Archive based on ArchiveVo data', () => {
     const archiveVo = {
       archiveId: 0,
+      archiveNbr: '0000-0000',
       fullName: 'archive name',
       createdDT: '2022-07-10T14:59:03.853Z',
       updatedDT: '2022-08-10T14:59:03.853Z',
@@ -11,6 +12,7 @@ describe('archiveVoToArchive', () => {
     const archive = archiveVoToArchive(archiveVo);
     expect(archive).toEqual({
       id: 0,
+      slug: '0000-0000',
       name: 'archive name',
       createdAt: new Date('2022-07-10T14:59:03.853Z'),
       updatedAt: new Date('2022-08-10T14:59:03.853Z'),

--- a/src/utils/archiveVoToArchive.ts
+++ b/src/utils/archiveVoToArchive.ts
@@ -6,6 +6,7 @@ import { formatTimestampAsUtc } from './formatTimestampAsUtc';
 
 export const archiveVoToArchive = (archiveVo: ArchiveVo): Archive => ({
   id: archiveVo.archiveId,
+  slug: archiveVo.archiveNbr,
   name: archiveVo.fullName,
   createdAt: new Date(formatTimestampAsUtc(archiveVo.createdDT)),
   updatedAt: new Date(formatTimestampAsUtc(archiveVo.updatedDT)),


### PR DESCRIPTION
This PR creates the concept of a `slug` for the `Archive` type.

Note that `archiveNbr` is a legacy name and is a bit confusing since it is not actually a number; this PR is proposing `slug` as a more meaningful term to refer to the attribute.  Slug is an existing concept: https://developer.mozilla.org/en-US/docs/Glossary/Slug

Resolves #87