### PR TITLE
Populate `isSftpDeletionEnabled` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- The `Account.isSftpDeletionEnabled` property is now populated based on the values provided by the Permanent API.
 
 ## [0.5.3] - 2023-04-03
 ### Added

--- a/src/api/__tests__/__snapshots__/getAuthenticatedAccountVo.test.ts.snap
+++ b/src/api/__tests__/__snapshots__/getAuthenticatedAccountVo.test.ts.snap
@@ -7,6 +7,7 @@ Object {
   "address": null,
   "address2": null,
   "agreed": null,
+  "allowSftpDeletion": false,
   "betaParticipant": null,
   "changePrimaryEmail": null,
   "changePrimaryPhone": null,

--- a/src/api/__tests__/fixtures/getAuthenticatedAccountVo/accountVo.json
+++ b/src/api/__tests__/fixtures/getAuthenticatedAccountVo/accountVo.json
@@ -18,6 +18,7 @@
     "emailStatus": "status.auth.unverified",
     "phoneStatus": "status.auth.none",
     "notificationPreferences": "{\"textPreference\": {\"apps\": {\"confirmations\": 1}, \"share\": {\"requests\": 1, \"activities\": 1, \"confirmations\": 1}, \"account\": {\"confirmations\": 1, \"recommendations\": 1}, \"archive\": {\"requests\": 1, \"confirmations\": 1}, \"relationships\": {\"requests\": 1, \"confirmations\": 1}}, \"emailPreference\": {\"apps\": {\"confirmations\": 1}, \"share\": {\"requests\": 1, \"activities\": 1, \"confirmations\": 1}, \"account\": {\"confirmations\": 1, \"recommendations\": 1}, \"archive\": {\"requests\": 1, \"confirmations\": 1}, \"relationships\": {\"requests\": 1, \"confirmations\": 1}}, \"inAppPreference\": {\"apps\": {\"confirmations\": 1}, \"share\": {\"requests\": 1, \"activities\": 1, \"confirmations\": 1}, \"account\": {\"confirmations\": 1, \"recommendations\": 1}, \"archive\": {\"requests\": 1, \"confirmations\": 1}, \"relationships\": {\"requests\": 1, \"confirmations\": 1}}}",
+    "allowSftpDeletion": false,
     "agreed": null,
     "optIn": null,
     "emailArray": null,

--- a/src/sdk/__tests__/fixtures/getAuthenticatedAccount/accountVo.json
+++ b/src/sdk/__tests__/fixtures/getAuthenticatedAccount/accountVo.json
@@ -18,6 +18,7 @@
     "emailStatus": "status.auth.unverified",
     "phoneStatus": "status.auth.none",
     "notificationPreferences": "{\"textPreference\": {\"apps\": {\"confirmations\": 1}, \"share\": {\"requests\": 1, \"activities\": 1, \"confirmations\": 1}, \"account\": {\"confirmations\": 1, \"recommendations\": 1}, \"archive\": {\"requests\": 1, \"confirmations\": 1}, \"relationships\": {\"requests\": 1, \"confirmations\": 1}}, \"emailPreference\": {\"apps\": {\"confirmations\": 1}, \"share\": {\"requests\": 1, \"activities\": 1, \"confirmations\": 1}, \"account\": {\"confirmations\": 1, \"recommendations\": 1}, \"archive\": {\"requests\": 1, \"confirmations\": 1}, \"relationships\": {\"requests\": 1, \"confirmations\": 1}}, \"inAppPreference\": {\"apps\": {\"confirmations\": 1}, \"share\": {\"requests\": 1, \"activities\": 1, \"confirmations\": 1}, \"account\": {\"confirmations\": 1, \"recommendations\": 1}, \"archive\": {\"requests\": 1, \"confirmations\": 1}, \"relationships\": {\"requests\": 1, \"confirmations\": 1}}}",
+    "allowSftpDeletion": false,
     "agreed": null,
     "optIn": null,
     "emailArray": null,

--- a/src/types/api/AccountVo.ts
+++ b/src/types/api/AccountVo.ts
@@ -6,6 +6,7 @@ export interface AccountVo extends BaseVo {
   // These fields map to those defined in the base library ArchiveVO
   // https://github.com/PermanentOrg/back-end/blob/main/library/base/vo/base.account.vo.php
   accountId: number;
+  allowSftpDeletion: boolean;
 }
 
 export const accountVoSchema: JSONSchemaType<AccountVo> = {
@@ -13,6 +14,9 @@ export const accountVoSchema: JSONSchemaType<AccountVo> = {
   properties: {
     accountId: {
       type: 'integer',
+    },
+    allowSftpDeletion: {
+      type: 'boolean',
     },
     createdDT: {
       type: 'string',
@@ -25,6 +29,7 @@ export const accountVoSchema: JSONSchemaType<AccountVo> = {
     'accountId',
     'createdDT',
     'updatedDT',
+    'allowSftpDeletion',
   ],
 };
 

--- a/src/utils/__tests__/accountVoToAccount.test.ts
+++ b/src/utils/__tests__/accountVoToAccount.test.ts
@@ -4,13 +4,14 @@ describe('accountVoToAccount', () => {
   it('should properly populate an Account based on AccountVo data', () => {
     const accountVo = {
       accountId: 0,
+      allowSftpDeletion: true,
       createdDT: '2022-07-10T14:59:03.853Z',
       updatedDT: '2022-08-10T14:59:03.853Z',
     };
     const account = accountVoToAccount(accountVo);
     expect(account).toEqual({
       id: 0,
-      isSftpDeletionEnabled: false,
+      isSftpDeletionEnabled: true,
       createdAt: new Date('2022-07-10T14:59:03.853Z'),
       updatedAt: new Date('2022-08-10T14:59:03.853Z'),
     });

--- a/src/utils/accountVoToAccount.ts
+++ b/src/utils/accountVoToAccount.ts
@@ -6,7 +6,7 @@ import { formatTimestampAsUtc } from './formatTimestampAsUtc';
 
 export const accountVoToAccount = (accountVo: AccountVo): Account => ({
   id: accountVo.accountId,
-  isSftpDeletionEnabled: false,
+  isSftpDeletionEnabled: accountVo.allowSftpDeletion,
   createdAt: new Date(formatTimestampAsUtc(accountVo.createdDT)),
   updatedAt: new Date(formatTimestampAsUtc(accountVo.updatedDT)),
 });


### PR DESCRIPTION
This PR utilizes the Permanent API to populate the `Account.isSftpDeletionEnabled` property.

Resolves #96