### PR TITLE
Separate upload from archive record creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Changed
+- The `createArchiveRecord` function no longer uploads files, clients must use the new `uploadFile` function for this.
+
+## Added
+- The `uploadFile` function now exists.
 
 ## [0.5.4] - 2023-04-18
 ### Fixed

--- a/src/sdk/__tests__/__snapshots__/createArchiveRecord.test.ts.snap
+++ b/src/sdk/__tests__/__snapshots__/createArchiveRecord.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`createArchiveRecord should create an ArchiveRecord  1`] = `
+exports[`createArchiveRecord should create an ArchiveRecord 1`] = `
 Object {
   "createdAt": 2023-01-23T21:02:40.000Z,
   "displayDate": 2023-01-23T21:02:40.000Z,

--- a/src/sdk/__tests__/createArchiveRecord.test.ts
+++ b/src/sdk/__tests__/createArchiveRecord.test.ts
@@ -1,69 +1,17 @@
 import nock from 'nock';
 import fs from 'fs';
-import { URL } from 'url';
 import { createArchiveRecord } from '..';
-import { bodyContainsMultipartFormFields } from '../../test/utils';
 
 describe('createArchiveRecord', () => {
-  it('should create an ArchiveRecord ', async () => {
-    const s3UploadVo = {
-      destinationUrl: 'https://permanet.local/_slifty/unprocessed/12345678-e6ef-4238-85d3-20001abebb63',
-      presignedPost: {
-        url: 'https://permanent.local/thisWouldBeAnAwsUrl',
-        fields: {
-          Key: '_slifty/unprocessed/12345678-e6ef-4238-85d3-20001abebb63',
-          bucket: 'permanent-local',
-          'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
-          'X-Amz-Credential': '12345678/20230123/us-west-2/s3/aws4_request',
-          'X-Amz-Date': '20230123T210239Z',
-          Policy: '123456789=',
-          'X-Amz-Signature': '1234567890',
-        },
-      },
-    };
-    const presignedPostUrl = new URL(s3UploadVo.presignedPost.url);
+  it('should create an ArchiveRecord', async () => {
     const filePath = `${__dirname}/fixtures/createArchiveRecord/myFile.txt`;
-    const fileDataStream = fs.createReadStream(filePath);
-    const fileData = fs.readFileSync(filePath);
     const { size: fileSize } = fs.statSync(filePath);
-
-    nock('https://permanent.local')
-      .post(
-        '/api/record/getPresignedUrl',
-        {
-          displayName: 'myFile',
-          parentFolderId: 1,
-          uploadFileName: 'myFile.txt',
-          fileType: 'text/plain',
-          size: fileSize,
-        },
-      )
-      .reply(
-        200,
-        s3UploadVo,
-        {
-          'Content-Type': 'application/json',
-        },
-      );
-
-    nock(presignedPostUrl.origin)
-      .post(
-        presignedPostUrl.pathname,
-        (body) => bodyContainsMultipartFormFields(
-          body,
-          {
-            ...s3UploadVo.presignedPost.fields,
-            file: fileData.toString(),
-          },
-        ),
-      )
-      .reply(200);
 
     nock('https://permanent.local')
       .post(
         '/api/record/registerRecord',
         {
-          s3url: s3UploadVo.destinationUrl,
+          s3url: 'https://permanet.local/_slifty/unprocessed/12345678-e6ef-4238-85d3-20001abebb63',
           displayName: 'myFile',
           parentFolderId: 1,
           uploadFileName: 'myFile.txt',
@@ -84,7 +32,7 @@ describe('createArchiveRecord', () => {
         bearerToken: '12345',
         baseUrl: 'https://permanent.local/api',
       },
-      fileDataStream,
+      'https://permanet.local/_slifty/unprocessed/12345678-e6ef-4238-85d3-20001abebb63',
       {
         size: fileSize,
         contentType: 'text/plain',

--- a/src/sdk/__tests__/uploadFile.test.ts
+++ b/src/sdk/__tests__/uploadFile.test.ts
@@ -1,0 +1,83 @@
+import nock from 'nock';
+import fs from 'fs';
+import { URL } from 'url';
+import { uploadFile } from '..';
+import { bodyContainsMultipartFormFields } from '../../test/utils';
+
+describe('uploadFile', () => {
+  it('should post file data to S3', async () => {
+    const s3UploadVo = {
+      destinationUrl: 'https://permanet.local/_slifty/unprocessed/12345678-e6ef-4238-85d3-20001abebb63',
+      presignedPost: {
+        url: 'https://permanent.local/thisWouldBeAnAwsUrl',
+        fields: {
+          Key: '_slifty/unprocessed/12345678-e6ef-4238-85d3-20001abebb63',
+          bucket: 'permanent-local',
+          'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
+          'X-Amz-Credential': '12345678/20230123/us-west-2/s3/aws4_request',
+          'X-Amz-Date': '20230123T210239Z',
+          Policy: '123456789=',
+          'X-Amz-Signature': '1234567890',
+        },
+      },
+    };
+    const presignedPostUrl = new URL(s3UploadVo.presignedPost.url);
+    const filePath = `${__dirname}/fixtures/createArchiveRecord/myFile.txt`;
+    const fileDataStream = fs.createReadStream(filePath);
+    const fileData = fs.readFileSync(filePath);
+    const { size: fileSize } = fs.statSync(filePath);
+
+    nock('https://permanent.local')
+      .post(
+        '/api/record/getPresignedUrl',
+        {
+          displayName: 'myFile',
+          parentFolderId: 1,
+          uploadFileName: 'myFile.txt',
+          fileType: 'text/plain',
+          size: fileSize,
+        },
+      )
+      .reply(
+        200,
+        s3UploadVo,
+        {
+          'Content-Type': 'application/json',
+        },
+      );
+
+    nock(presignedPostUrl.origin)
+      .post(
+        presignedPostUrl.pathname,
+        (body) => bodyContainsMultipartFormFields(
+          body,
+          {
+            ...s3UploadVo.presignedPost.fields,
+            file: fileData.toString(),
+          },
+        ),
+      )
+      .reply(200);
+
+    const fileUrl = await uploadFile(
+      {
+        bearerToken: '12345',
+        baseUrl: 'https://permanent.local/api',
+      },
+      fileDataStream,
+      {
+        size: fileSize,
+        contentType: 'text/plain',
+      },
+      {
+        displayName: 'myFile',
+        fileSystemCompatibleName: 'myFile.txt',
+      },
+      {
+        id: 1,
+      },
+    );
+
+    expect(fileUrl).toBe('https://permanet.local/_slifty/unprocessed/12345678-e6ef-4238-85d3-20001abebb63');
+  });
+});

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -7,3 +7,4 @@ export * from './getArchiveRecord';
 export * from './getArchives';
 export * from './getAuthenticatedAccount';
 export * from './getFolder';
+export * from './uploadFile';


### PR DESCRIPTION
This PR separates the "upload" step from the "archive record registration" step when creating an archive record.  It means SDK clients need to either call `uploadFile` or, in the case of internal clients, upload the file to s3 directly.

Resolves #116