### PR TITLE
Disable dependabot for node types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
     ignore:
       - dependency-name: "node-fetch"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: ".github/workflows"


### PR DESCRIPTION
This PR disables dependabot for the @node/types pacakge (since dependabot isn't as smart about matching the node version we're using)