### PR TITLE
Deprecated the contentType parameter of createArchiveRecord requests

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -155,7 +155,7 @@ ArchiveRecord {
 ```
 CreateArchiveRecordParams {
   s3Url: string;
-  file: Pick<File, 'contentType' | 'size'>;
+  file: Pick<Partial<File>, 'contentType'> & Pick<File, 'size'>;
   item: Pick<ArchiveRecord, 'displayName' | 'fileSystemCompatibleName'>;
   parentFolder: Pick<Folder, 'id'>;
 }
@@ -164,6 +164,9 @@ CreateArchiveRecordParams {
 s3Url will generally be the value returned by `uploadFile`. Run
 `createArchiveRecord` to store information about uploaded files in the
 Permanent database.
+
+file.contentType is deprecated. The field is still accepted for backwards compatibility, but it is not used.
+The content type is determined by the file extension of the uploaded file.
 
 ```
 createArchiveRecord(

--- a/src/api/createRecordVo.ts
+++ b/src/api/createRecordVo.ts
@@ -13,7 +13,7 @@ export interface CreateRecordVoRequest {
   displayName: string;
   parentFolderId: number;
   uploadFileName: string;
-  fileType: string;
+  fileType?: string;
   size: number;
 }
 

--- a/src/sdk/createArchiveRecord.ts
+++ b/src/sdk/createArchiveRecord.ts
@@ -13,7 +13,7 @@ import type {
 
 export interface CreateArchiveRecordParams {
   s3Url: string;
-  file: Pick<File, 'contentType' | 'size'>;
+  file: Pick<Partial<File>, 'contentType'> & Pick<File, 'size'>;
   item: Pick<ArchiveRecord, 'displayName' | 'fileSystemCompatibleName'>;
   parentFolder: Pick<Folder, 'id'>;
 }


### PR DESCRIPTION
Currently, createArchiveRecord requires a file.contentType field. This field has no effect, and has confused users in the past. To remedy this, this commit makes the field optional, and adds a note to the documentation that it is deprecated and has no effect.