### PR TITLE
Retry calls on certain http responses

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,9 @@
       "sort-exports"
     ],
     "extends": [
-      "plugin:@typescript-eslint/all",
+      "plugin:@typescript-eslint/recommended",
+      "plugin:@typescript-eslint/recommended-requiring-type-checking",
+      "plugin:@typescript-eslint/strict",
       "airbnb-base",
       "airbnb-typescript/base"
     ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- SDK clients can now be configured to `retryOn` various HTTP status codes.
+
 ## [0.9.1] - 2025-03-13
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.11.0",
+        "fetch-retry": "^6.0.0",
         "form-data": "^4.0.0",
         "node-fetch": "^2.6.7"
       },
@@ -3566,6 +3567,12 @@
       "dependencies": {
         "bser": "2.1.1"
       }
+    },
+    "node_modules/fetch-retry": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-6.0.0.tgz",
+      "integrity": "sha512-BUFj1aMubgib37I3v4q78fYo63Po7t4HUPTpQ6/QE6yK6cIQrP+W43FYToeTEyg5m2Y7eFUtijUuAv/PDlWuag==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   },
   "dependencies": {
     "ajv": "^8.11.0",
+    "fetch-retry": "^6.0.0",
     "form-data": "^4.0.0",
     "node-fetch": "^2.6.7"
   },

--- a/src/types/sdk/ClientConfiguration.ts
+++ b/src/types/sdk/ClientConfiguration.ts
@@ -2,4 +2,5 @@ export interface ClientConfiguration {
   bearerToken: string;
   baseUrl?: string;
   stelaBaseUrl?: string;
+  retryOn?: number[];
 }

--- a/src/utils/__tests__/makePermanentApiCall.test.ts
+++ b/src/utils/__tests__/makePermanentApiCall.test.ts
@@ -55,4 +55,31 @@ describe('makePermanentApiCall', () => {
 
     expect(responseBody).toEqual('it worked');
   });
+
+  it('should retry if configured to do so', async () => {
+    const mock = nock('https://permanent.local', {
+      reqheaders: {
+        Authorization: 'Bearer 12345',
+        'Request-Version': '2',
+        'Content-Type': 'application/json',
+      },
+    })
+      .get('/api/testing')
+      .reply(404, 'it did not work')
+      .get('/api/testing')
+      .reply(200, 'it worked');
+
+    const response = await makePermanentApiCall(
+      {
+        bearerToken: '12345',
+        baseUrl: 'https://permanent.local/api',
+        retryOn: [404],
+      },
+      '/testing',
+    );
+    const responseBody = await response.text();
+
+    expect(responseBody).toEqual('it worked');
+    expect(mock.isDone()).toBe(true); // All mocked responses were invoked
+  });
 });

--- a/src/utils/__tests__/makeStelaApiCall.test.ts
+++ b/src/utils/__tests__/makeStelaApiCall.test.ts
@@ -71,4 +71,25 @@ describe('makeStelaApiCall', () => {
     );
     await expect(call).rejects.toThrow(HttpResponseError);
   });
+
+  it('should retry if configured to do so', async () => {
+    const mock = nock('https://api.permanent.local')
+      .get('/api/v2/testing')
+      .reply(404, 'it did not work')
+      .get('/api/v2/testing')
+      .reply(200, 'it worked');
+
+    const response = await makeStelaApiCall(
+      {
+        bearerToken: '12345',
+        stelaBaseUrl: 'https://api.permanent.local/api/v2',
+        retryOn: [404],
+      },
+      '/testing',
+    );
+    const responseBody = await response.text();
+
+    expect(responseBody).toEqual('it worked');
+    expect(mock.isDone()).toBe(true); // All mocked responses were invoked
+  });
 });

--- a/src/utils/getFetch.ts
+++ b/src/utils/getFetch.ts
@@ -1,0 +1,11 @@
+import originalFetch from 'node-fetch';
+import fetchRetry from 'fetch-retry';
+import type { ClientConfiguration } from '../types/sdk/ClientConfiguration';
+
+const getFetch = (clientConfiguration: ClientConfiguration) => fetchRetry(originalFetch, {
+  retries: 3,
+  retryDelay: (attempt) => (2 ** attempt) * 1000,
+  retryOn: clientConfiguration.retryOn ?? [],
+});
+
+export { getFetch };

--- a/src/utils/makePermanentApiCall.ts
+++ b/src/utils/makePermanentApiCall.ts
@@ -1,5 +1,5 @@
-import fetch from 'node-fetch';
 import { HttpResponseError } from '../errors';
+import { getFetch } from './getFetch';
 import type {
   RequestInit,
   Response,
@@ -25,6 +25,7 @@ export const makePermanentApiCall = async (
   endpointPath: string,
   requestParameters?: RequestInit,
 ): Promise<Response> => {
+  const fetch = getFetch(clientConfiguration);
   const headers = {
     ...generateApiHeaders(clientConfiguration),
     ...(requestParameters?.headers),

--- a/src/utils/makeStelaApiCall.ts
+++ b/src/utils/makeStelaApiCall.ts
@@ -1,5 +1,5 @@
-import fetch from 'node-fetch';
 import { HttpResponseError } from '../errors';
+import { getFetch } from './getFetch';
 import type {
   RequestInit,
   Response,
@@ -25,6 +25,7 @@ export const makeStelaApiCall = async (
   endpointPath: string,
   requestParameters?: RequestInit,
 ): Promise<Response> => {
+  const fetch = getFetch(clientConfiguration);
   const headers = {
     ...generateApiHeaders(clientConfiguration),
     ...(requestParameters?.headers),


### PR DESCRIPTION
This PR makes it possible for callers to request the SDK to perform exponentially decaying retries in the event of particular HTTP responses.

It also updates our lint rules (we were using `all` which is actually not recommended)

Resolves #149