### PR TITLE
Enable love rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,7 +40,6 @@ export default defineConfig([
 			// These rules are enabled by the `love` ruleset and our code base violates them.
 			// We're disabling them here so we can re-enable one-by-one alongside necessary fixes.
 			"@typescript-eslint/no-magic-numbers": "off",
-			"@typescript-eslint/no-misused-spread": "off",
 			"@typescript-eslint/explicit-function-return-type": "off",
 			"@typescript-eslint/no-unsafe-type-assertion": "off",
 			"@typescript-eslint/return-await": "off",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,7 +40,6 @@ export default defineConfig([
 			// These rules are enabled by the `love` ruleset and our code base violates them.
 			// We're disabling them here so we can re-enable one-by-one alongside necessary fixes.
 			"@typescript-eslint/no-magic-numbers": "off",
-			"@typescript-eslint/return-await": "off",
 			"import/enforce-node-protocol-usage": "off",
 			"@typescript-eslint/consistent-type-exports": "off",
 			"@typescript-eslint/array-type": "off",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,7 +40,6 @@ export default defineConfig([
 			// These rules are enabled by the `love` ruleset and our code base violates them.
 			// We're disabling them here so we can re-enable one-by-one alongside necessary fixes.
 			"@typescript-eslint/no-magic-numbers": "off",
-			"@typescript-eslint/strict-boolean-expressions": "off",
 			"@typescript-eslint/no-misused-spread": "off",
 			"@typescript-eslint/explicit-function-return-type": "off",
 			"@typescript-eslint/no-unsafe-type-assertion": "off",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,10 +36,6 @@ export default defineConfig([
 				},
 			],
 			"@typescript-eslint/require-await": "off",
-
-			// These rules are enabled by the `love` ruleset and our code base violates them.
-			// We're disabling them here so we can re-enable one-by-one alongside necessary fixes.
-			"@typescript-eslint/no-magic-numbers": "off",
 		},
 	},
 	{

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,7 +40,6 @@ export default defineConfig([
 			// These rules are enabled by the `love` ruleset and our code base violates them.
 			// We're disabling them here so we can re-enable one-by-one alongside necessary fixes.
 			"@typescript-eslint/no-magic-numbers": "off",
-			"import/enforce-node-protocol-usage": "off",
 			"@typescript-eslint/consistent-type-exports": "off",
 			"@typescript-eslint/array-type": "off",
 			"@typescript-eslint/prefer-destructuring": "off",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,7 +40,6 @@ export default defineConfig([
 			// These rules are enabled by the `love` ruleset and our code base violates them.
 			// We're disabling them here so we can re-enable one-by-one alongside necessary fixes.
 			"@typescript-eslint/no-magic-numbers": "off",
-			"@typescript-eslint/no-unsafe-type-assertion": "off",
 			"@typescript-eslint/return-await": "off",
 			"import/enforce-node-protocol-usage": "off",
 			"@typescript-eslint/consistent-type-exports": "off",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,7 +40,6 @@ export default defineConfig([
 			// These rules are enabled by the `love` ruleset and our code base violates them.
 			// We're disabling them here so we can re-enable one-by-one alongside necessary fixes.
 			"@typescript-eslint/no-magic-numbers": "off",
-			"eslint-comments/require-description": "off",
 			"n/no-path-concat": "off",
 		},
 	},

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,7 +40,6 @@ export default defineConfig([
 			// These rules are enabled by the `love` ruleset and our code base violates them.
 			// We're disabling them here so we can re-enable one-by-one alongside necessary fixes.
 			"@typescript-eslint/no-magic-numbers": "off",
-			"@typescript-eslint/prefer-destructuring": "off",
 			"eslint-comments/require-description": "off",
 			"n/no-path-concat": "off",
 		},

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,7 +40,6 @@ export default defineConfig([
 			// These rules are enabled by the `love` ruleset and our code base violates them.
 			// We're disabling them here so we can re-enable one-by-one alongside necessary fixes.
 			"@typescript-eslint/no-magic-numbers": "off",
-			"n/no-path-concat": "off",
 		},
 	},
 	{

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,7 +40,6 @@ export default defineConfig([
 			// These rules are enabled by the `love` ruleset and our code base violates them.
 			// We're disabling them here so we can re-enable one-by-one alongside necessary fixes.
 			"@typescript-eslint/no-magic-numbers": "off",
-			"@typescript-eslint/array-type": "off",
 			"@typescript-eslint/prefer-destructuring": "off",
 			"eslint-comments/require-description": "off",
 			"n/no-path-concat": "off",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,7 +35,6 @@ export default defineConfig([
 					caughtErrorsIgnorePattern: "^_",
 				},
 			],
-			"@typescript-eslint/require-await": "off",
 		},
 	},
 	{

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,7 +40,6 @@ export default defineConfig([
 			// These rules are enabled by the `love` ruleset and our code base violates them.
 			// We're disabling them here so we can re-enable one-by-one alongside necessary fixes.
 			"@typescript-eslint/no-magic-numbers": "off",
-			"@typescript-eslint/explicit-function-return-type": "off",
 			"@typescript-eslint/no-unsafe-type-assertion": "off",
 			"@typescript-eslint/return-await": "off",
 			"import/enforce-node-protocol-usage": "off",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,11 +40,18 @@ export default defineConfig([
 			// These rules are enabled by the `love` ruleset and our code base violates them.
 			// We're disabling them here so we can re-enable one-by-one alongside necessary fixes.
 			"@typescript-eslint/no-magic-numbers": "off",
-			"@typescript-eslint/consistent-type-exports": "off",
 			"@typescript-eslint/array-type": "off",
 			"@typescript-eslint/prefer-destructuring": "off",
 			"eslint-comments/require-description": "off",
 			"n/no-path-concat": "off",
+		},
+	},
+	{
+		files: ["**/index.ts"],
+
+		rules: {
+			// Indexes shouldn't care about the nature of the exports they are collating
+			"@typescript-eslint/consistent-type-exports": "off",
 		},
 	},
 	{

--- a/src/api/__tests__/createFolderVo.test.ts
+++ b/src/api/__tests__/createFolderVo.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import nock from "nock";
 import { createFolderVo } from "..";
 import { ValidationError } from "../../errors";
@@ -10,9 +11,13 @@ describe("createFolderVo", () => {
 				parentFolderId: 1,
 				failOnDuplicateName: false,
 			})
-			.replyWithFile(200, `${__dirname}/fixtures/createFolderVo/folder.json`, {
-				"Content-Type": "application/json",
-			});
+			.replyWithFile(
+				200,
+				path.join(__dirname, "fixtures", "createFolderVo", "folder.json"),
+				{
+					"Content-Type": "application/json",
+				},
+			);
 
 		const folderVo = await createFolderVo(
 			{

--- a/src/api/__tests__/createRecordVo.test.ts
+++ b/src/api/__tests__/createRecordVo.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import nock from "nock";
 import { createRecordVo } from "..";
 import { ValidationError } from "../../errors";
@@ -16,7 +17,7 @@ describe("createRecordVo", () => {
 			})
 			.replyWithFile(
 				200,
-				`${__dirname}/fixtures/createRecordVo/recordVo.json`,
+				path.join(__dirname, "fixtures", "createRecordVo", "recordVo.json"),
 				{
 					"Content-Type": "application/json",
 				},

--- a/src/api/__tests__/createS3UploadVo.test.ts
+++ b/src/api/__tests__/createS3UploadVo.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import nock from "nock";
 import { createS3UploadVo } from "..";
 import { ValidationError } from "../../errors";
@@ -14,7 +15,7 @@ describe("createS3UploadVo", () => {
 			})
 			.replyWithFile(
 				200,
-				`${__dirname}/fixtures/createS3UploadVo/s3Upload.json`,
+				path.join(__dirname, "fixtures", "createS3UploadVo", "s3Upload.json"),
 				{
 					"Content-Type": "application/json",
 				},

--- a/src/api/__tests__/createShareLinkVo.test.ts
+++ b/src/api/__tests__/createShareLinkVo.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import nock from "nock";
 import { createShareLinkVo } from "..";
 
@@ -12,7 +13,7 @@ describe("createShareLink", () => {
 			})
 			.replyWithFile(
 				200,
-				`${__dirname}/fixtures/createShareLink/shareLinkVo.json`,
+				path.join(__dirname, "fixtures", "createShareLink", "shareLinkVo.json"),
 				{ "Content-Type": "application/json" },
 			);
 

--- a/src/api/__tests__/getAllArchiveVos.test.ts
+++ b/src/api/__tests__/getAllArchiveVos.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import nock from "nock";
 import { getAllArchiveVos } from "..";
 import { ValidationError } from "../../errors";
@@ -8,7 +9,12 @@ describe("getAllArchiveVos", () => {
 			.get("/api/archive/getAllArchives")
 			.replyWithFile(
 				200,
-				`${__dirname}/fixtures/getAllArchiveVos/multipleArchives.json`,
+				path.join(
+					__dirname,
+					"fixtures",
+					"getAllArchiveVos",
+					"multipleArchives.json",
+				),
 				{
 					"Content-Type": "application/json",
 				},

--- a/src/api/__tests__/getArchiveRootFolderVo.test.ts
+++ b/src/api/__tests__/getArchiveRootFolderVo.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import nock from "nock";
 import { getArchiveRootFolderVo } from "..";
 import { ValidationError } from "../../errors";
@@ -9,7 +10,12 @@ describe("getArchiveRootFolderVo", () => {
 			.query({ archiveId: 1 })
 			.replyWithFile(
 				200,
-				`${__dirname}/fixtures/getArchiveRootFolderVo/archiveRoot.json`,
+				path.join(
+					__dirname,
+					"fixtures",
+					"getArchiveRootFolderVo",
+					"archiveRoot.json",
+				),
 				{
 					"Content-Type": "application/json",
 				},

--- a/src/api/__tests__/getAuthenticatedAccountVo.test.ts
+++ b/src/api/__tests__/getAuthenticatedAccountVo.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import nock from "nock";
 import { getAuthenticatedAccountVo } from "..";
 import { ValidationError } from "../../errors";
@@ -8,7 +9,12 @@ describe("getAuthenticatedAccountVo", () => {
 			.get("/api/account/getAuthenticatedAccount")
 			.replyWithFile(
 				200,
-				`${__dirname}/fixtures/getAuthenticatedAccountVo/accountVo.json`,
+				path.join(
+					__dirname,
+					"fixtures",
+					"getAuthenticatedAccountVo",
+					"accountVo.json",
+				),
 				{
 					"Content-Type": "application/json",
 				},

--- a/src/api/__tests__/getFolderVo.test.ts
+++ b/src/api/__tests__/getFolderVo.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import nock from "nock";
 import { getFolderVo } from "..";
 import { ValidationError } from "../../errors";
@@ -10,9 +11,13 @@ describe("getFolderVo", () => {
 				folderId: 7457,
 				archiveId: 1,
 			})
-			.replyWithFile(200, `${__dirname}/fixtures/getFolderVo/folder.json`, {
-				"Content-Type": "application/json",
-			});
+			.replyWithFile(
+				200,
+				path.join(__dirname, "fixtures", "getFolderVo", "folder.json"),
+				{
+					"Content-Type": "application/json",
+				},
+			);
 
 		const folderVo = await getFolderVo(
 			{
@@ -35,7 +40,12 @@ describe("getFolderVo", () => {
 			})
 			.replyWithFile(
 				200,
-				`${__dirname}/fixtures/getFolderVo/folderWithNullDisplayDt.json`,
+				path.join(
+					__dirname,
+					"fixtures",
+					"getFolderVo",
+					"folderWithNullDisplayDt.json",
+				),
 				{
 					"Content-Type": "application/json",
 				},

--- a/src/api/__tests__/getRecordVo.test.ts
+++ b/src/api/__tests__/getRecordVo.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import nock from "nock";
 import { getRecordVo } from "..";
 import { ValidationError } from "../../errors";
@@ -10,9 +11,13 @@ describe("getRecordVo", () => {
 				recordId: 512,
 				archiveId: 1,
 			})
-			.replyWithFile(200, `${__dirname}/fixtures/getRecordVo/recordVo.json`, {
-				"Content-Type": "application/json",
-			});
+			.replyWithFile(
+				200,
+				path.join(__dirname, "fixtures", "getRecordVo", "recordVo.json"),
+				{
+					"Content-Type": "application/json",
+				},
+			);
 
 		const recordVo = await getRecordVo(
 			{

--- a/src/api/__tests__/updateShareLinkVo.test.ts
+++ b/src/api/__tests__/updateShareLinkVo.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import nock from "nock";
 import { updateShareLinkVo } from "..";
 
@@ -14,7 +15,12 @@ describe("updateShareLinkVo", () => {
 			})
 			.replyWithFile(
 				200,
-				`${__dirname}/fixtures/updateShareLinkVo/shareLinkVo.json`,
+				path.join(
+					__dirname,
+					"fixtures",
+					"updateShareLinkVo",
+					"shareLinkVo.json",
+				),
 				{ "Content-Type": "application/json" },
 			);
 

--- a/src/errors/ValidationError.ts
+++ b/src/errors/ValidationError.ts
@@ -13,7 +13,7 @@ export class ValidationError extends Error {
 		input?: unknown,
 	) {
 		super(message);
-		this.name = this.constructor.name;
+		this.name = "ValidationError";
 		this.errors = errors;
 		this.input = input;
 	}

--- a/src/sdk/__tests__/__snapshots__/getFolder.test.ts.snap
+++ b/src/sdk/__tests__/__snapshots__/getFolder.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`getFolder should return a Folder 1`] = `
 {
@@ -3542,7 +3542,7 @@ exports[`getFolder should return a Folder 1`] = `
   "createdAt": 2025-03-12T14:32:10.000Z,
   "displayDate": 2025-03-12T14:34:17.000Z,
   "fileSystemCompatibleName": "garf",
-  "fileSystemId": "1575054",
+  "fileSystemId": 1575054,
   "folders": [
     {
       "archiveRecords": [],
@@ -3569,7 +3569,7 @@ exports[`getFolder should return a Folder 1`] = `
       "updatedAt": 2025-03-12T22:15:34.000Z,
     },
   ],
-  "id": "189434",
+  "id": 189434,
   "name": "garf",
   "size": 65750943,
   "updatedAt": 2025-03-12T14:38:26.000Z,

--- a/src/sdk/__tests__/createArchiveRecord.test.ts
+++ b/src/sdk/__tests__/createArchiveRecord.test.ts
@@ -1,4 +1,4 @@
-import fs from "fs";
+import fs from "node:fs";
 import nock from "nock";
 import { createArchiveRecord } from "..";
 

--- a/src/sdk/__tests__/createArchiveRecord.test.ts
+++ b/src/sdk/__tests__/createArchiveRecord.test.ts
@@ -1,10 +1,16 @@
+import path from "node:path";
 import fs from "node:fs";
 import nock from "nock";
 import { createArchiveRecord } from "..";
 
 describe("createArchiveRecord", () => {
 	it("should create an ArchiveRecord", async () => {
-		const filePath = `${__dirname}/fixtures/createArchiveRecord/myFile.txt`;
+		const filePath = path.join(
+			__dirname,
+			"fixtures",
+			"createArchiveRecord",
+			"myFile.txt",
+		);
 		const { size: fileSize } = fs.statSync(filePath);
 
 		nock("https://permanent.local")
@@ -20,7 +26,12 @@ describe("createArchiveRecord", () => {
 			})
 			.replyWithFile(
 				200,
-				`${__dirname}/fixtures/createArchiveRecord/recordVo.json`,
+				path.join(
+					__dirname,
+					"fixtures",
+					"createArchiveRecord",
+					"recordVo.json",
+				),
 				{
 					"Content-Type": "application/json",
 				},
@@ -52,7 +63,12 @@ describe("createArchiveRecord", () => {
 	});
 
 	it("should pass the failOnDuplicateName parameter to the API", async () => {
-		const filePath = `${__dirname}/fixtures/createArchiveRecord/myFile.txt`;
+		const filePath = path.join(
+			__dirname,
+			"fixtures",
+			"createArchiveRecord",
+			"myFile.txt",
+		);
 		const { size: fileSize } = fs.statSync(filePath);
 
 		nock("https://permanent.local")
@@ -68,7 +84,12 @@ describe("createArchiveRecord", () => {
 			})
 			.replyWithFile(
 				200,
-				`${__dirname}/fixtures/createArchiveRecord/recordVo.json`,
+				path.join(
+					__dirname,
+					"fixtures",
+					"createArchiveRecord",
+					"recordVo.json",
+				),
 				{
 					"Content-Type": "application/json",
 				},

--- a/src/sdk/__tests__/createFolder.test.ts
+++ b/src/sdk/__tests__/createFolder.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import nock from "nock";
 import { createFolder } from "..";
 
@@ -9,9 +10,13 @@ describe("createFolder", () => {
 				parentFolderId: 1,
 				failOnDuplicateName: false,
 			})
-			.replyWithFile(200, `${__dirname}/fixtures/createFolder/folder.json`, {
-				"Content-Type": "application/json",
-			});
+			.replyWithFile(
+				200,
+				path.join(__dirname, "fixtures", "createFolder", "folder.json"),
+				{
+					"Content-Type": "application/json",
+				},
+			);
 
 		const folder = await createFolder(
 			{
@@ -37,9 +42,13 @@ describe("createFolder", () => {
 				parentFolderId: 1,
 				failOnDuplicateName: true,
 			})
-			.replyWithFile(200, `${__dirname}/fixtures/createFolder/folder.json`, {
-				"Content-Type": "application/json",
-			});
+			.replyWithFile(
+				200,
+				path.join(__dirname, "fixtures", "createFolder", "folder.json"),
+				{
+					"Content-Type": "application/json",
+				},
+			);
 
 		const folder = await createFolder(
 			{

--- a/src/sdk/__tests__/createShareLink.test.ts
+++ b/src/sdk/__tests__/createShareLink.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import nock from "nock";
 import { createShareLink } from "..";
 import { AccessRole } from "../../types";
@@ -13,7 +14,7 @@ describe("createShareLink", () => {
 			})
 			.replyWithFile(
 				200,
-				`${__dirname}/fixtures/createShareLink/shareLinkVo.json`,
+				path.join(__dirname, "fixtures", "createShareLink", "shareLinkVo.json"),
 				{ "Content-Type": "application/json" },
 			);
 

--- a/src/sdk/__tests__/getArchiveFolders.test.ts
+++ b/src/sdk/__tests__/getArchiveFolders.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import nock from "nock";
 import { getArchiveFolders } from "..";
 
@@ -10,7 +11,12 @@ describe("getArchiveFolders", () => {
 			})
 			.replyWithFile(
 				200,
-				`${__dirname}/fixtures/getArchiveFolders/archiveRoot.json`,
+				path.join(
+					__dirname,
+					"fixtures",
+					"getArchiveFolders",
+					"archiveRoot.json",
+				),
 				{
 					"Content-Type": "application/json",
 				},

--- a/src/sdk/__tests__/getArchiveRecord.test.ts
+++ b/src/sdk/__tests__/getArchiveRecord.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import nock from "nock";
 import { getArchiveRecord } from "..";
 
@@ -9,9 +10,13 @@ describe("getArchiveRecord", () => {
 				recordId: 512,
 				archiveId: 1,
 			})
-			.replyWithFile(200, `${__dirname}/fixtures/getRecord/recordVo.json`, {
-				"Content-Type": "application/json",
-			});
+			.replyWithFile(
+				200,
+				path.join(__dirname, "fixtures", "getRecord", "recordVo.json"),
+				{
+					"Content-Type": "application/json",
+				},
+			);
 
 		const folder = await getArchiveRecord(
 			{

--- a/src/sdk/__tests__/getArchives.test.ts
+++ b/src/sdk/__tests__/getArchives.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import nock from "nock";
 import { getArchives } from "..";
 
@@ -7,7 +8,12 @@ describe("getArchives", () => {
 			.get("/api/archive/getAllArchives")
 			.replyWithFile(
 				200,
-				`${__dirname}/fixtures/getArchives/multipleArchives.json`,
+				path.join(
+					__dirname,
+					"fixtures",
+					"getArchives",
+					"multipleArchives.json",
+				),
 				{
 					"Content-Type": "application/json",
 				},

--- a/src/sdk/__tests__/getAuthenticatedAccount.test.ts
+++ b/src/sdk/__tests__/getAuthenticatedAccount.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import nock from "nock";
 import { getAuthenticatedAccount } from "..";
 
@@ -7,7 +8,12 @@ describe("getAuthenticatedAccount", () => {
 			.get("/api/account/getAuthenticatedAccount")
 			.replyWithFile(
 				200,
-				`${__dirname}/fixtures/getAuthenticatedAccount/accountVo.json`,
+				path.join(
+					__dirname,
+					"fixtures",
+					"getAuthenticatedAccount",
+					"accountVo.json",
+				),
 				{
 					"Content-Type": "application/json",
 				},

--- a/src/sdk/__tests__/getFolder.test.ts
+++ b/src/sdk/__tests__/getFolder.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import nock from "nock";
 import { getFolder } from "..";
 
@@ -8,9 +9,13 @@ describe("getFolder", () => {
 			.query({
 				"folderIds[]": "7457",
 			})
-			.replyWithFile(200, `${__dirname}/fixtures/getFolder/stelaFolder.json`, {
-				"Content-Type": "application/json",
-			});
+			.replyWithFile(
+				200,
+				path.join(__dirname, "fixtures", "getFolder", "stelaFolder.json"),
+				{
+					"Content-Type": "application/json",
+				},
+			);
 
 		const firstChildrenPage = nock("https://api.permanent.local")
 			.get("/api/v2/folder/7457/children")
@@ -19,7 +24,12 @@ describe("getFolder", () => {
 			})
 			.replyWithFile(
 				200,
-				`${__dirname}/fixtures/getFolder/stelaChildrenPageOne.json`,
+				path.join(
+					__dirname,
+					"fixtures",
+					"getFolder",
+					"stelaChildrenPageOne.json",
+				),
 				{
 					"Content-Type": "application/json",
 				},
@@ -33,7 +43,12 @@ describe("getFolder", () => {
 			})
 			.replyWithFile(
 				200,
-				`${__dirname}/fixtures/getFolder/stelaChildrenPageTwo.json`,
+				path.join(
+					__dirname,
+					"fixtures",
+					"getFolder",
+					"stelaChildrenPageTwo.json",
+				),
 				{
 					"Content-Type": "application/json",
 				},
@@ -63,7 +78,7 @@ describe("getFolder", () => {
 			})
 			.replyWithFile(
 				200,
-				`${__dirname}/fixtures/getFolder/stelaNoFolder.json`,
+				path.join(__dirname, "fixtures", "getFolder", "stelaNoFolder.json"),
 				{
 					"Content-Type": "application/json",
 				},

--- a/src/sdk/__tests__/updateShareLink.test.ts
+++ b/src/sdk/__tests__/updateShareLink.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import nock from "nock";
 import { updateShareLink } from "..";
 import { AccessRole, Status } from "../../types";
@@ -15,7 +16,7 @@ describe("updateShareLink", () => {
 			})
 			.replyWithFile(
 				200,
-				`${__dirname}/fixtures/updateShareLink/shareLinkVo.json`,
+				path.join(__dirname, "fixtures", "updateShareLink", "shareLinkVo.json"),
 				{ "Content-Type": "application/json" },
 			);
 

--- a/src/sdk/__tests__/uploadFile.test.ts
+++ b/src/sdk/__tests__/uploadFile.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import fs from "node:fs";
 import { URL } from "node:url";
 import nock from "nock";
@@ -23,7 +24,12 @@ describe("uploadFile", () => {
 			},
 		};
 		const presignedPostUrl = new URL(s3UploadVo.presignedPost.url);
-		const filePath = `${__dirname}/fixtures/createArchiveRecord/myFile.txt`;
+		const filePath = path.join(
+			__dirname,
+			"fixtures",
+			"createArchiveRecord",
+			"myFile.txt",
+		);
 		const fileDataStream = fs.createReadStream(filePath);
 		const fileData = fs.readFileSync(filePath);
 		const { size: fileSize } = fs.statSync(filePath);

--- a/src/sdk/__tests__/uploadFile.test.ts
+++ b/src/sdk/__tests__/uploadFile.test.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import { URL } from "url";
+import fs from "node:fs";
+import { URL } from "node:url";
 import nock from "nock";
 import { uploadFile } from "..";
 import { bodyContainsMultipartFormFields } from "../../test/utils";

--- a/src/sdk/deleteArchiveRecord.ts
+++ b/src/sdk/deleteArchiveRecord.ts
@@ -8,4 +8,6 @@ export interface DeleteArchiveRecordParams {
 export const deleteArchiveRecord = async (
 	clientConfiguration: ClientConfiguration,
 	params: DeleteArchiveRecordParams,
-): Promise<void> => deleteRecordVo(clientConfiguration, params.archiveRecordId);
+): Promise<void> => {
+	await deleteRecordVo(clientConfiguration, params.archiveRecordId);
+};

--- a/src/sdk/deleteFolder.ts
+++ b/src/sdk/deleteFolder.ts
@@ -8,4 +8,6 @@ export interface DeleteFolderParams {
 export const deleteFolder = async (
 	clientConfiguration: ClientConfiguration,
 	params: DeleteFolderParams,
-): Promise<void> => deleteFolderVo(clientConfiguration, params.folderId);
+): Promise<void> => {
+	await deleteFolderVo(clientConfiguration, params.folderId);
+};

--- a/src/sdk/getFolder.ts
+++ b/src/sdk/getFolder.ts
@@ -19,8 +19,8 @@ const LOAD_CHILDREN_PAGE_SIZE = 100;
 const loadAllStelaChildrenForFolder = async (
 	clientConfiguration: ClientConfiguration,
 	folderId: number,
-): Promise<(StelaFolder | StelaRecord)[]> => {
-	const children: (StelaRecord | StelaFolder)[] = [];
+): Promise<Array<StelaFolder | StelaRecord>> => {
+	const children: Array<StelaRecord | StelaFolder> = [];
 	let cursor: string | null = null;
 	let allChildrenLoaded = false;
 
@@ -45,7 +45,7 @@ const loadAllStelaChildrenForFolder = async (
 };
 
 const getFoldersFromStelaChildren = (
-	stelaChildren: (StelaFolder | StelaRecord)[],
+	stelaChildren: Array<StelaFolder | StelaRecord>,
 ): Folder[] =>
 	stelaChildren.reduce((acc: Folder[], stelaChild) => {
 		if (isStelaFolder(stelaChild)) {
@@ -55,7 +55,7 @@ const getFoldersFromStelaChildren = (
 	}, []);
 
 const getArchiveRecordsFromStelaChildren = (
-	stelaChildren: (StelaFolder | StelaRecord)[],
+	stelaChildren: Array<StelaFolder | StelaRecord>,
 ): ArchiveRecord[] =>
 	stelaChildren.reduce((acc: ArchiveRecord[], stelaChild) => {
 		if (isStelaRecord(stelaChild)) {

--- a/src/sdk/getFolder.ts
+++ b/src/sdk/getFolder.ts
@@ -33,7 +33,10 @@ const loadAllStelaChildrenForFolder = async (
 			cursor,
 			LOAD_CHILDREN_PAGE_SIZE,
 		);
-		cursor = page.pagination.nextCursor;
+		const {
+			pagination: { nextCursor },
+		} = page;
+		cursor = nextCursor;
 		children.push(...page.items);
 
 		// If this was a full page, loop one more time to get the next page

--- a/src/sdk/uploadFile.ts
+++ b/src/sdk/uploadFile.ts
@@ -1,6 +1,6 @@
 import { createS3UploadVo } from "../api";
 import { executePresignedPost } from "../utils";
-import type { Readable } from "stream";
+import type { Readable } from "node:stream";
 import type {
 	ArchiveRecord,
 	File,

--- a/src/stela/getStelaFolder.ts
+++ b/src/stela/getStelaFolder.ts
@@ -1,5 +1,10 @@
-import { makeStelaApiCall } from "../utils";
-import type { ClientConfiguration, Items, StelaFolder } from "../types";
+import { makeStelaApiCall, typedJsonParse } from "../utils";
+import {
+	generateIsItems,
+	stelaFolderSchema,
+	type ClientConfiguration,
+	type StelaFolder,
+} from "../types";
 
 export const getStelaFolder = async (
 	clientConfiguration: ClientConfiguration,
@@ -14,7 +19,10 @@ export const getStelaFolder = async (
 		{ method: "GET" },
 	);
 	const responseText = await response.text();
-	const { items } = JSON.parse(responseText) as Items<StelaFolder>;
+	const { items } = typedJsonParse(
+		responseText,
+		generateIsItems(stelaFolderSchema),
+	);
 	if (items.length === 0) {
 		throw new Error("Folder not found");
 	}

--- a/src/stela/getStelaFolder.ts
+++ b/src/stela/getStelaFolder.ts
@@ -19,12 +19,16 @@ export const getStelaFolder = async (
 		{ method: "GET" },
 	);
 	const responseText = await response.text();
-	const { items } = typedJsonParse(
-		responseText,
-		generateIsItems(stelaFolderSchema),
-	);
-	if (items.length === 0) {
+	const {
+		items: [item],
+	} = typedJsonParse(responseText, generateIsItems(stelaFolderSchema));
+
+	/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition --
+	 * This is one of the documented cases where a disable is considered
+	 * necessary by the rule itself: https://typescript-eslint.io/rules/no-unnecessary-condition/#possibly-undefined-indexed-access
+	 */
+	if (item === undefined) {
 		throw new Error("Folder not found");
 	}
-	return items[0];
+	return item;
 };

--- a/src/stela/getStelaFolderChildren.ts
+++ b/src/stela/getStelaFolderChildren.ts
@@ -1,11 +1,13 @@
 import { URLSearchParams } from "node:url";
-import { makeStelaApiCall } from "../utils";
-import type {
-	ClientConfiguration,
-	PaginatedItems,
-	StelaFolder,
-	StelaRecord,
+import { makeStelaApiCall, typedJsonParse } from "../utils";
+import {
+	generateIsPaginatedItems,
+	type ClientConfiguration,
+	type PaginatedItems,
+	type StelaFolder,
+	type StelaRecord,
 } from "../types";
+import { stelaFolderChildSchema } from "../types/stela/StelaFolderChild";
 
 export const getStelaFolderChildren = async (
 	clientConfiguration: ClientConfiguration,
@@ -25,5 +27,8 @@ export const getStelaFolderChildren = async (
 		{ method: "GET" },
 	);
 	const responseText = await response.text();
-	return JSON.parse(responseText) as PaginatedItems<StelaFolder | StelaRecord>;
+	return typedJsonParse(
+		responseText,
+		generateIsPaginatedItems(stelaFolderChildSchema),
+	);
 };

--- a/src/test/utils/__tests__/bodyContainsMultipartFormFields.test.ts
+++ b/src/test/utils/__tests__/bodyContainsMultipartFormFields.test.ts
@@ -1,7 +1,7 @@
 import { bodyContainsMultipartFormFields } from "..";
 
 describe("bodyContainsMultipartFormFields", () => {
-	it("should match a valid body ", async () => {
+	it("should match a valid body ", () => {
 		const body = `----------------------------369405283061745602785268
 Content-Disposition: form-data; name="firstField"
 
@@ -22,7 +22,7 @@ hello`;
 		expect(bodyContainsMultipartFormFields(body, expectedFields)).toBe(true);
 	});
 
-	it("should not match fields values with future field values", async () => {
+	it("should not match fields values with future field values", () => {
 		const body = `----------------------------369405283061745602785268
 Content-Disposition: form-data; name="firstField"
 
@@ -43,7 +43,7 @@ hello`;
 		expect(bodyContainsMultipartFormFields(body, expectedFields)).toBe(false);
 	});
 
-	it("should not match a body that is not a string", async () => {
+	it("should not match a body that is not a string", () => {
 		const body = {
 			firstField: "foo",
 			secondField: "foo",

--- a/src/types/api/FolderVo.ts
+++ b/src/types/api/FolderVo.ts
@@ -9,7 +9,7 @@ export interface FolderVo extends BaseVo {
 	// https://github.com/PermanentOrg/back-end/blob/main/api/core/folder/vo/folder.vo.php
 	folderId: number;
 	folder_linkId: number;
-	ChildItemVOs: (FolderVo | RecordVo)[];
+	ChildItemVOs: Array<FolderVo | RecordVo>;
 	displayName: string;
 	downloadName: string;
 	displayDT?: string | null;

--- a/src/types/stela/Items.ts
+++ b/src/types/stela/Items.ts
@@ -1,3 +1,21 @@
+import { ajv } from "../../utils";
+import type { JSONSchemaType, ValidateFunction } from "ajv";
+
 export interface Items<T> {
 	items: T[];
 }
+
+export const generateIsItems = <T>(
+	itemSchema: JSONSchemaType<T>,
+): ValidateFunction<Items<T>> =>
+	ajv.compile<Items<T>>({
+		type: "object",
+		properties: {
+			items: {
+				type: "array",
+				items: itemSchema,
+			},
+		},
+		required: ["items"],
+		additionalProperties: false,
+	});

--- a/src/types/stela/PaginatedItems.ts
+++ b/src/types/stela/PaginatedItems.ts
@@ -1,3 +1,6 @@
+import type { JSONSchemaType, ValidateFunction } from "ajv";
+import { ajv } from "../../utils";
+
 export interface PaginatedItems<T> {
 	items: T[];
 	pagination: {
@@ -6,3 +9,28 @@ export interface PaginatedItems<T> {
 		totalPages: number;
 	};
 }
+
+export const generateIsPaginatedItems = <T>(
+	itemSchema: JSONSchemaType<T>,
+): ValidateFunction<PaginatedItems<T>> =>
+	ajv.compile<PaginatedItems<T>>({
+		type: "object",
+		properties: {
+			items: {
+				type: "array",
+				items: itemSchema,
+			},
+			pagination: {
+				type: "object",
+				properties: {
+					nextCursor: { type: "string" },
+					nextPage: { type: "string" },
+					totalPages: { type: "number" },
+				},
+				required: ["nextCursor", "nextPage", "totalPages"],
+				additionalProperties: false,
+			},
+		},
+		required: ["items", "pagination"],
+		additionalProperties: false,
+	});

--- a/src/types/stela/StelaFolderChild.ts
+++ b/src/types/stela/StelaFolderChild.ts
@@ -1,0 +1,12 @@
+import { type StelaRecord, stelaRecordSchema } from "./StelaRecord";
+import { type StelaFolder, stelaFolderSchema } from "./StelaFolder";
+import type { JSONSchemaType } from "ajv";
+
+type StelaFolderChild = StelaRecord | StelaFolder;
+
+const stelaFolderChildSchema: JSONSchemaType<StelaFolderChild> = {
+	type: "object",
+	oneOf: [stelaRecordSchema, stelaFolderSchema],
+};
+
+export { StelaFolderChild, stelaFolderChildSchema };

--- a/src/types/stela/StelaFolderChild.ts
+++ b/src/types/stela/StelaFolderChild.ts
@@ -9,4 +9,4 @@ const stelaFolderChildSchema: JSONSchemaType<StelaFolderChild> = {
 	oneOf: [stelaRecordSchema, stelaFolderSchema],
 };
 
-export { StelaFolderChild, stelaFolderChildSchema };
+export { type StelaFolderChild, stelaFolderChildSchema };

--- a/src/utils/executePresignedPost.ts
+++ b/src/utils/executePresignedPost.ts
@@ -18,7 +18,7 @@ export const executePresignedPost = async (
 		formData.append(key, request.bodyFields[key]);
 	});
 	formData.append("file", request.fileData, { knownLength: request.fileSize });
-	return fetch(request.url, {
+	return await fetch(request.url, {
 		method: "POST",
 		body: formData,
 	});

--- a/src/utils/executePresignedPost.ts
+++ b/src/utils/executePresignedPost.ts
@@ -1,6 +1,6 @@
 import FormData from "form-data";
 import fetch from "node-fetch";
-import type { Readable } from "stream";
+import type { Readable } from "node:stream";
 import type { Response } from "node-fetch";
 
 export interface PresignedPostRequest {

--- a/src/utils/folderVoToFolder.ts
+++ b/src/utils/folderVoToFolder.ts
@@ -9,12 +9,14 @@ const extractFolderVos = (items: unknown[]): FolderVo[] =>
 const extractRecordVos = (items: unknown[]): RecordVo[] =>
 	items.filter<RecordVo>((item): item is RecordVo => isRecordVo(item));
 
+const DEFAULT_FOLDER_SIZE = 0;
+
 export const folderVoToFolder = (folderVo: FolderVo): Folder => ({
 	id: folderVo.folderId,
 	fileSystemId: folderVo.folder_linkId,
 	name: folderVo.displayName,
 	fileSystemCompatibleName: folderVo.downloadName,
-	size: 0,
+	size: DEFAULT_FOLDER_SIZE,
 	createdAt: new Date(formatTimestampAsUtc(folderVo.createdDT)),
 	updatedAt: new Date(formatTimestampAsUtc(folderVo.updatedDT)),
 	displayDate:

--- a/src/utils/generateEnumTypeguard.ts
+++ b/src/utils/generateEnumTypeguard.ts
@@ -1,9 +1,4 @@
-// This is a modified version of code written by StackOverflow user @jcalz
-// https://stackoverflow.com/a/58278753/159522
 export const generateEnumTypeguard =
 	<GenericEnum extends object>(genericEnum: GenericEnum) =>
-	(value: unknown): value is GenericEnum[keyof GenericEnum] => {
-		const token = value as GenericEnum[keyof GenericEnum];
-		const validTokens = Object.values(genericEnum);
-		return validTokens.includes(token);
-	};
+	(value: unknown): value is GenericEnum[keyof GenericEnum] =>
+		Object.values(genericEnum).some((v) => v === value);

--- a/src/utils/getFetch.ts
+++ b/src/utils/getFetch.ts
@@ -1,14 +1,18 @@
 import originalFetch from "node-fetch";
 import fetchRetry from "fetch-retry";
 import type { ClientConfiguration } from "../types/sdk/ClientConfiguration";
+const DEFAULT_RETRIES = 3;
+const EXPONENTIAL_BACKOFF_FACTOR = 2;
+const MS_PER_SECOND = 1000;
 
 const getFetch = (
 	clientConfiguration: ClientConfiguration,
 ): ReturnType<typeof fetchRetry<typeof originalFetch>> =>
 	fetchRetry(originalFetch, {
-		retries: clientConfiguration.retries ?? 3,
+		retries: clientConfiguration.retries ?? DEFAULT_RETRIES,
 		retryDelay:
-			clientConfiguration.retryDelay ?? ((attempt) => 2 ** attempt * 1000),
+			clientConfiguration.retryDelay ??
+			((attempt) => EXPONENTIAL_BACKOFF_FACTOR ** attempt * MS_PER_SECOND),
 		retryOn: clientConfiguration.retryOn ?? [],
 	});
 

--- a/src/utils/getFetch.ts
+++ b/src/utils/getFetch.ts
@@ -2,7 +2,9 @@ import originalFetch from "node-fetch";
 import fetchRetry from "fetch-retry";
 import type { ClientConfiguration } from "../types/sdk/ClientConfiguration";
 
-const getFetch = (clientConfiguration: ClientConfiguration) =>
+const getFetch = (
+	clientConfiguration: ClientConfiguration,
+): ReturnType<typeof fetchRetry<typeof originalFetch>> =>
 	fetchRetry(originalFetch, {
 		retries: clientConfiguration.retries ?? 3,
 		retryDelay:

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from "./ajv";
 export * from "./accountVoToAccount";
 export * from "./archiveVoToArchive";
 export * from "./executePresignedPost";

--- a/src/utils/makePermanentApiCall.ts
+++ b/src/utils/makePermanentApiCall.ts
@@ -1,3 +1,4 @@
+import { Headers } from "node-fetch";
 import { HttpResponseError } from "../errors";
 import { getFetch } from "./getFetch";
 import type { RequestInit, Response } from "node-fetch";
@@ -25,10 +26,12 @@ export const makePermanentApiCall = async (
 	requestParameters?: RequestInit,
 ): Promise<Response> => {
 	const fetch = getFetch(clientConfiguration);
-	const headers = {
-		...generateApiHeaders(clientConfiguration),
-		...requestParameters?.headers,
-	};
+	const headers = generateApiHeaders(clientConfiguration);
+	const headerOverrides = new Headers(requestParameters?.headers ?? {});
+	headerOverrides.forEach((value, key) => {
+		headers[key] = value;
+	});
+
 	const response = await fetch(
 		resolveEndpointPathToUrl(clientConfiguration, endpointPath),
 		{

--- a/src/utils/makeStelaApiCall.ts
+++ b/src/utils/makeStelaApiCall.ts
@@ -1,3 +1,4 @@
+import { Headers } from "node-fetch";
 import { HttpResponseError } from "../errors";
 import { getFetch } from "./getFetch";
 import type { RequestInit, Response } from "node-fetch";
@@ -26,10 +27,11 @@ export const makeStelaApiCall = async (
 	requestParameters?: RequestInit,
 ): Promise<Response> => {
 	const fetch = getFetch(clientConfiguration);
-	const headers = {
-		...generateApiHeaders(clientConfiguration),
-		...requestParameters?.headers,
-	};
+	const headers = generateApiHeaders(clientConfiguration);
+	const headerOverrides = new Headers(requestParameters?.headers ?? {});
+	headerOverrides.forEach((value, key) => {
+		headers[key] = value;
+	});
 	const response = await fetch(
 		resolveEndpointPathToUrl(clientConfiguration, endpointPath),
 		{

--- a/src/utils/shareLinkVoToShareLink.ts
+++ b/src/utils/shareLinkVoToShareLink.ts
@@ -8,6 +8,9 @@ import {
 } from "../types";
 import { formatTimestampAsUtc } from "./formatTimestampAsUtc";
 
+const PERMANENT_API_AUTO_APPROVE_DISABLED = 0;
+const PERMANENT_API_PREVIEW_DISABLED = 0;
+
 const shareLinkVoStatusToStatus = (status: string): Status =>
 	isStatus(status) ? status : Status.Undefined;
 
@@ -38,11 +41,11 @@ export const shareLinkVoToShareLink = (shareLinkVo: ShareLinkVo): ShareLink => {
 		autoApprove:
 			shareLinkVo.autoApproveToggle !== undefined &&
 			shareLinkVo.autoApproveToggle !== null &&
-			shareLinkVo.autoApproveToggle !== 0,
+			shareLinkVo.autoApproveToggle !== PERMANENT_API_AUTO_APPROVE_DISABLED,
 		showPreview:
 			shareLinkVo.previewToggle !== undefined &&
 			shareLinkVo.previewToggle !== null &&
-			shareLinkVo.previewToggle !== 0,
+			shareLinkVo.previewToggle !== PERMANENT_API_PREVIEW_DISABLED,
 		defaultAccessRole,
 		status,
 		createdAt,

--- a/src/utils/shareLinkVoToShareLink.ts
+++ b/src/utils/shareLinkVoToShareLink.ts
@@ -38,11 +38,11 @@ export const shareLinkVoToShareLink = (shareLinkVo: ShareLinkVo): ShareLink => {
 		autoApprove:
 			shareLinkVo.autoApproveToggle !== undefined &&
 			shareLinkVo.autoApproveToggle !== null &&
-			!!shareLinkVo.autoApproveToggle,
+			shareLinkVo.autoApproveToggle !== 0,
 		showPreview:
 			shareLinkVo.previewToggle !== undefined &&
 			shareLinkVo.previewToggle !== null &&
-			!!shareLinkVo.previewToggle,
+			shareLinkVo.previewToggle !== 0,
 		defaultAccessRole,
 		status,
 		createdAt,

--- a/src/utils/stelaFolderToFolder.ts
+++ b/src/utils/stelaFolderToFolder.ts
@@ -1,11 +1,13 @@
 import type { StelaFolder, Folder } from "../types";
 
+const DEFAULT_FOLDER_SIZE = 0;
+
 export const stelaFolderToFolder = (stelaFolder: StelaFolder): Folder => ({
 	id: stelaFolder.folderId,
 	fileSystemId: stelaFolder.folderLinkId,
 	name: stelaFolder.displayName,
 	fileSystemCompatibleName: stelaFolder.downloadName,
-	size: stelaFolder.size ?? 0,
+	size: stelaFolder.size ?? DEFAULT_FOLDER_SIZE,
 	createdAt: new Date(stelaFolder.createdAt),
 	updatedAt: new Date(stelaFolder.updatedAt),
 	displayDate:

--- a/src/utils/typedJsonParse.ts
+++ b/src/utils/typedJsonParse.ts
@@ -3,7 +3,7 @@ import type { ValidateFunction } from "ajv";
 
 export const typedJsonParse = <T>(
 	jsonString: string,
-	typeguard: ValidateFunction<T>,
+	typeguard: ((input: unknown) => input is T) & Partial<ValidateFunction>,
 ): T => {
 	const value = JSON.parse(jsonString) as unknown;
 	if (typeguard(value)) {
@@ -12,7 +12,7 @@ export const typedJsonParse = <T>(
 
 	throw new ValidationError(
 		`Invalid JSON object structure when validated by '${typeguard.name}'`,
-		typeguard.errors,
+		typeguard.errors ?? [],
 		value,
 	);
 };


### PR DESCRIPTION
This PR enables our previously-disabled `love` lint ruleset / other disabled rules.

Some of these commits translated to actual code being written to properly implement various pieces of the code base where we were doing unsafe things (for example the no unsafe type casting rule exposed the lack of a proper type guard when making stela calls)